### PR TITLE
Push all .pyc files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-nightbus-app/main.pyc
-nightbus-app/database.pyc
-nightbus-app/decorators.pyc
-nightbus-app/post_to_fb.pyc
-nightbus-app/schema.pyc
+nightbus-app/*.pyc


### PR DESCRIPTION
makes code cleaner and prevent any future unwanted .pyc file from finding its way into your local machine